### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Injectable
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/a45cc5935a5c16b837ed/maintainability)](https://codeclimate.com/github/rubiconmd/injectable/maintainability)![Ruby](https://github.com/rubiconmd/injectable/workflows/Ruby/badge.svg)
+![Rspec](https://github.com/rubiconmd/injectable/workflows/RSpec/badge.svg)![Rubocop](https://github.com/rubiconmd/injectable/workflows/rubocop/badge.svg)
 
 `Injectable` is an opinionated and declarative [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection) library for ruby.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Injectable
 
-![Rspec](https://github.com/rubiconmd/injectable/workflows/RSpec/badge.svg)![Rubocop](https://github.com/rubiconmd/injectable/workflows/rubocop/badge.svg)
+![RSpec](https://github.com/rubiconmd/injectable/workflows/RSpec/badge.svg)![Rubocop](https://github.com/rubiconmd/injectable/workflows/rubocop/badge.svg)
 
 `Injectable` is an opinionated and declarative [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection) library for ruby.
 


### PR DESCRIPTION
Removes CodeClimate badge
Fixes Ruby because the job was renamed to RSpec
Adds Rubocop badge